### PR TITLE
Fix kernel odd size assertions

### DIFF
--- a/src/similar.cu
+++ b/src/similar.cu
@@ -9,7 +9,8 @@ torch::Tensor similar_cuda_forward(
 ) {
     TypeCheck(x_ori);
     TypeCheck(x_loc);
-    AT_ASSERTM(!casual_mask || (kH & 1 == 1 && kW & 1 == 1), "If casual_mask is true, the kernel size must be odd!");
+    AT_ASSERTM(!casual_mask || ((kH & 1) == 1 && (kW & 1) == 1),
+               "If casual_mask is true, the kernel size must be odd!");
     const int batch = x_ori.size(0);
     const int channels = x_ori.size(1);
     const int height = x_ori.size(2);

--- a/src/weighting.cu
+++ b/src/weighting.cu
@@ -12,7 +12,8 @@ torch::Tensor weighting_cuda_forward(
     const int channels = x_ori.size(1);
     const int height = x_weight.size(1);
     const int width = x_weight.size(2);
-    AT_ASSERTM(!casual_mask || (kH & 1 == 1 && kW & 1 == 1), "If casual_mask is true, the kernel size must be odd!");
+    AT_ASSERTM(!casual_mask || ((kH & 1) == 1 && (kW & 1) == 1),
+               "If casual_mask is true, the kernel size must be odd!");
 
     const int batch_ori = x_ori.size(0);
     const int channels_ori = x_ori.size(1);


### PR DESCRIPTION
## Summary
- fix parentheses in odd size checks for kernels

## Testing
- `python test/similar.py` *(fails: ModuleNotFoundError: No module named 'torch')*
- `python test/weighting.py` *(fails: ModuleNotFoundError: No module named 'torch')*